### PR TITLE
Upgrade to latest supported software and modernize where needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
 		}
 	],
 	"require": {
-		"php": "^7.0",
-		"guzzlehttp/guzzle": "^6.2",
+		"php": "^7.3 || ^8.0",
+		"guzzlehttp/guzzle": "^7.0.1",
         "ext-json": "*"
     },
 	"require-dev": {
-		"phpunit/phpunit": "^6.0"
+		"phpunit/phpunit": "^8.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
 	<logging>
 		<log type="tap" target="build/report.tap"/>
 		<log type="junit" target="build/report.junit.xml"/>
-		<log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+		<log type="coverage-html" target="build/coverage" showUncoveredFiles="true"/>
 		<log type="coverage-text" target="build/coverage.txt"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 	</logging>

--- a/src/OnPremiseClient.php
+++ b/src/OnPremiseClient.php
@@ -310,7 +310,7 @@ class OnPremiseClient extends Client {
             }
             return $this->client->request($method, $this->siteUrl . '/_api/Web/' . $action, $options);
         } catch (RequestException $requestException) {
-            throw new \Exception(Psr7\str($requestException->getResponse()));
+            throw new \Exception(Psr7\Message::toString($requestException->getResponse()));
         }
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,20 +4,15 @@ namespace DelaneyMethod\Sharepoint\Test;
 
 use PHPUnit\Framework\TestCase;
 use DelaneyMethod\Sharepoint\Client;
-use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Client as GuzzleClient;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\ClientException;
-use Spatie\Dropbox\Exceptions\BadRequest;
-use DelaneyMethod\Sharepoint\UploadSessionCursor;
 
 class ClientTest extends TestCase
 {
 	/** @test */
 	public function it_can_be_instantiated()
 	{
-		$client = new Client('test_token');
+		$client = new Client('YOUR_TEAM_SITE_NAME', 'https://YOUR_SITE.sharepoint.com',
+            'https://YOUR_SITE.sharepoint.com/:i:/r/sites/YOUR_TEAM_SITE_NAME/Shared%20Documents', 'YOUR_CLIENT_ID',
+            'YOUR_CLIENT_SECRET', false, 'YOUR_ACCESS_TOKEN');
 
 		$this->assertInstanceOf(Client::class, $client);
 	}

--- a/tests/OnPremiseClientTest.php
+++ b/tests/OnPremiseClientTest.php
@@ -11,8 +11,15 @@ class OnPremiseClientTest extends TestCase {
      */
     private $client = null;
 
-    public function setUp() {
-        $this->client = new OnPremiseClient();
+    public function setUp(): void {
+        $this->client = new OnPremiseClient([
+            'siteName' => 'YOUR_TEAM_SITE_NAME',
+            'siteUrl' => 'https://YOUR_SITE.sharepoint.com',
+            'publicUrl' => 'https://YOUR_SITE.sharepoint.com/:i:/r/sites/YOUR_TEAM_SITE_NAME/Shared%20Documents',
+            'client' => [
+                'verify' => false
+            ]
+        ]);
     }
 
     public function testCreateFolder()


### PR DESCRIPTION
Hi,

in an effort to use flysystem-sharepoint within a Laravel 8 application, I would need to have this package upgraded to support PHP8 (and obviously still support the oldest supported PHP version 7.3).

I updated the Guzzle HTTP and PHPUnit dependencies as well, so that we have a future-proof version. 

Due to those changes, I needed to change some the use of `Psr7\str` to `Psr7\Message::toString` and the phpunit.xml.dist file.

Lastly some changes to the test classes were necessary.

Here's a detailed list of all changes:
* Remove unnecessarily included classes.
* Add correct arguments to Client constructor call.
* Set supported PHP version to ^7.3 || ^8.0.
* Use the latest Guzzle HTTP version (v7.x).
* Use the latest phpunit version whilst supporting PHP v7.3.
* Use Psr7\Message from Guzzle HTTP.
* Use the fully correct function signature for the setUp function and pass a suitable configuration array to the OnPremiseClient constructor.
* Update phpunit.xml.dist to the correct XML structure for PHPUnit 8.5

Best regards,
Guus